### PR TITLE
feat: Button 컴포넌트 구현

### DIFF
--- a/global.d.ts
+++ b/global.d.ts
@@ -1,0 +1,25 @@
+// global.d.ts
+declare module "*.module.css" {
+  const classes: { [key: string]: string };
+  export default classes;
+}
+
+declare module "*.module.scss" {
+  const classes: { [key: string]: string };
+  export default classes;
+}
+
+declare module "*.png" {
+  const value: string;
+  export default value;
+}
+
+declare module "*.svg" {
+  const content: any;
+  export default content;
+}
+
+declare module "*.mp4" {
+  const src: string;
+  export default src;
+}

--- a/src/components/Button.module.css
+++ b/src/components/Button.module.css
@@ -1,0 +1,42 @@
+.button-container {
+  border: none;
+  border-radius: 10px;
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 24px;
+
+  white-space: nowrap;
+  cursor: pointer;
+}
+
+.small {
+  padding: 11px 20px;
+}
+
+.medium {
+  padding: 13px 40px;
+}
+
+.large {
+  padding: 13px 175px;
+}
+
+.normal {
+  background-color: var(--green-200);
+  border: none;
+  color: var(--gray-50);
+}
+
+.normal:disabled {
+  background-color: var(--gray-300);
+}
+
+.empty {
+  background-color: transparent;
+  border: 1px solid var(--green-200);
+  color: var(--green-200);
+}
+
+.full-width {
+  width: 100%;
+}

--- a/src/components/Button.tsx
+++ b/src/components/Button.tsx
@@ -1,0 +1,37 @@
+import styles from "./Button.module.css";
+import { ReactNode } from "react";
+
+interface ButtonProps {
+  children: ReactNode;
+  mode?: "normal" | "empty";
+  fullWidth?: boolean;
+  disabled?: boolean;
+  loading?: boolean;
+  size?: "small" | "medium" | "large";
+  type?: "button" | "submit" | "reset";
+  onClick?: () => void;
+}
+
+export default function Button({
+  children,
+  mode = "normal",
+  fullWidth = false,
+  disabled = false,
+  loading = false,
+  size = "medium",
+  type = "button",
+  onClick,
+}: ButtonProps) {
+  return (
+    <button
+      className={`${styles["button-container"]} ${
+        mode === "empty" ? styles["empty"] : styles["normal"]
+      } ${fullWidth ? styles["full-width"] : ""} ${styles[size]}`}
+      disabled={disabled}
+      type={type}
+      onClick={onClick}
+    >
+      {loading ? "편집 중 ..." : children}
+    </button>
+  );
+}


### PR DESCRIPTION
#26 
공통으로 사용할 수 있는 Button 컴포넌트를 구현했습니다

ex)내 위키 만들기, 로그인, 목록으로 등

버튼에 필요 프랍만 내려 사용하시면 됩니다.
Props : children, mode, fullWidth, disabled, loading, size, type, onClick
*주요 사용법은 이슈에 정리했습니다

