### PR TITLE
Feat: Url 복사 및 Toast 알림 기능 추가

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "react": "^18",
         "react-dom": "^18",
         "react-hook-form": "^7.53.1",
+        "react-toastify": "^10.0.6",
         "zustand": "^5.0.0"
       },
       "devDependencies": {
@@ -3572,6 +3573,15 @@
       "integrity": "sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==",
       "license": "MIT"
     },
+    "node_modules/clsx": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
+      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/color-convert": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -6955,6 +6965,19 @@
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/react-toastify": {
+      "version": "10.0.6",
+      "resolved": "https://registry.npmjs.org/react-toastify/-/react-toastify-10.0.6.tgz",
+      "integrity": "sha512-yYjp+omCDf9lhZcrZHKbSq7YMuK0zcYkDFTzfRFgTXkTFHZ1ToxwAonzA4JI5CxA91JpjFLmwEsZEgfYfOqI1A==",
+      "license": "MIT",
+      "dependencies": {
+        "clsx": "^2.1.0"
+      },
+      "peerDependencies": {
+        "react": ">=18",
+        "react-dom": ">=18"
+      }
     },
     "node_modules/read-cache": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "react": "^18",
     "react-dom": "^18",
     "react-hook-form": "^7.53.1",
+    "react-toastify": "^10.0.6",
     "zustand": "^5.0.0"
   },
   "devDependencies": {

--- a/src/components/ui/CustomLink.tsx
+++ b/src/components/ui/CustomLink.tsx
@@ -1,30 +1,25 @@
-import Image from "next/image";
-import Link from "next/link";
-import linkIcon from "@/assets/icon/ic_link.svg";
+import LinkIcon from "/public/icons/ic_link.svg";
 
 interface CustomLinkProps {
   link: string;
   size?: "small" | "medium";
+  handleClick: () => void;
 }
 
-const CustomLink = ({ link, size = "medium" }: CustomLinkProps) => {
-  const imageSize = {
-    small: { width: 16, height: 16 },
-    medium: { width: 20, height: 20 },
-  };
-
+const CustomLink = ({
+  link,
+  size = "medium",
+  handleClick,
+}: CustomLinkProps) => {
   return (
-    <div className="flex items-center gap-[5px] w-fit px-[10px] py-[3px] rounded-[10px] bg-green-50 text-green-200">
-      <Image
-        src={linkIcon}
-        width={imageSize[size].width}
-        height={imageSize[size].height}
-        alt="링크 아이콘"
-      />
-      <Link className={size === "medium" ? "text-md" : "text-xs"} href={link}>
-        {link}
-      </Link>
-    </div>
+    <button
+      type="button"
+      onClick={handleClick}
+      className="flex items-center gap-[5px] w-fit px-[10px] py-[3px] rounded-[10px] bg-green-50 text-green-200 hover:bg-[#d1f0e7]"
+    >
+      <LinkIcon className={`${size === "medium" ? "w-5 h-5" : "w-4 h-4"}`} />
+      <p className={`${size === "medium" ? "text-md" : "text-xs"}`}>{link}</p>
+    </button>
   );
 };
 

--- a/src/containers/CustomLinkContainer.tsx
+++ b/src/containers/CustomLinkContainer.tsx
@@ -1,0 +1,45 @@
+import { useRouter } from "next/router";
+import { useEffect, useState } from "react";
+import CustomLink from "@/components/ui/CustomLink";
+import { toast } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+
+const CustomLinkContainer = () => {
+  const router = useRouter();
+  const [fullUrl, setFullUrl] = useState("");
+  const [isToastVisible, setIsToastVisible] = useState(false);
+
+  useEffect(() => {
+    const url = `${window.location.origin}${router.asPath}`;
+    setFullUrl(url);
+  }, [router.asPath]);
+
+  const copyToClipboard = async () => {
+    await navigator.clipboard.writeText(fullUrl);
+  };
+
+  const notify = () => {
+    if (!isToastVisible) {
+      setIsToastVisible(true);
+      toast.success("위키 링크가 복사되었습니다.", {
+        onClose: () => setIsToastVisible(false),
+        // className은 임시로 설정, Toast 커스텀하는 방법 찾는중
+        className:
+          "font-medium w-[247px] rounded-[10px] font-pretendard border border-[#4CBFA4] bg-[#EEF9F6] text-md h-[50px] px-[20px] py-[13px] text-[#32A68A]",
+      });
+    }
+  };
+
+  const handleClick = () => {
+    copyToClipboard();
+    notify();
+  };
+
+  return (
+    <div>
+      <CustomLink link={fullUrl} handleClick={handleClick} />
+    </div>
+  );
+};
+
+export default CustomLinkContainer;

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,12 +1,21 @@
-import "@/styles/global.css";
 import { Header } from "@/components/Layout/Header";
 import type { AppProps } from "next/app";
+import { ToastContainer } from "react-toastify";
+import "react-toastify/dist/ReactToastify.css";
+import "@/styles/global.css";
 
 export default function App({ Component, pageProps }: AppProps) {
   return (
     <>
       <Header />
       <Component {...pageProps} />
+      <ToastContainer
+        position="top-center"
+        autoClose={1000}
+        pauseOnHover={false}
+        closeButton={false}
+        limit={1}
+      />
     </>
   );
 }


### PR DESCRIPTION
## 수정사항
- `CustomLink`컴포넌트를 누르면 해당 주소로 이동하던 것을 클립 보드에 저장하고, Toast 알림이 뜨도록 수정했습니다.

## React Toastify

### 1. 설치
```js
npm install --save react-toastify
yarn add react-toastify
```

### 2. 기본 설정
앱의 최상위 컴포넌트(ex: App.tsx)에서 `ToastContainer`를 추가해야 합니다. 
이 컴포넌트는 모든 Toast 알림을 렌더링하는 역할을 합니다.
```js
import { ToastContainer } from "react-toastify";
import "react-toastify/dist/ReactToastify.css";      // react-toastify 기본 스타일

export default function App({ Component, pageProps }: AppProps) {
  return (
    <>
      <Component {...pageProps} />
      <ToastContainer />
    </>
  );
}
```

### 3. Toast 알림 생성 
Toast 알림을 생성하려면 `toast`함수를 사용하며, [다양한 옵션](https://fkhadra.github.io/react-toastify/api/toast-container/)을 지원합니다.
```js
import { toast } from "react-toastify";
const notify = () => {
  toast.success("위키 링크가 복사되었습니다.", {
    position: "top-center", // 알림의 위치 설정
    autoClose: 1000, // 자동으로 닫히는 시간 (ms)
    pauseOnHover: false, // 마우스를 올리면 자동 닫힘 기능 on/off
    draggable: true, // 드래그 가능 여부
  });
};
```

### 4. 알림 호출
저는 버튼의 onClick에 넣어서 사용했습니다. 
```js
return <button onClick={notify}>알림 표시</button>;
```

### 5. 스타일 커스터마이징
여기 부분은 아직 시도 중입니다. 
개별적으로 스타일을 주고 싶으면 아래처럼 `className`에 추가하거나 `_app.tsx`의 `ToastContainer`에 추가하면 모든 Toast에 공통으로 적용할 수 있습니다. 
다만, 잘 적용되지 않는 스타일들도 있어서, `react-toastify/dist/ReactToastify.css` 파일의 설정값들을 참고하여 `global.css`에서 덮어쓰는 방식으로 진행해보려고 합니다.

```js
toast.success("위키 링크가 복사되었습니다.", {
  onClose: () => setIsToastVisible(false),
  className:
    "font-pretendard font-medium rounded-[10px] border border-[#4CBFA4] bg-[#EEF9F6] text-[#32A68A]",
});
```