### PR TITLE
Refactor: WikiList 페이지 {code} 아닌 {user.name}으로 수정

### DIFF
--- a/src/components/WikiCard.tsx
+++ b/src/components/WikiCard.tsx
@@ -45,9 +45,9 @@ const WikiCard = ({ info }: WikiCardProps) => {
       </section>
       <section className="flex justify-between align-middle w-full px-[24px] py-[24px] bg-gray-100">
         <span className="text-gray-400 text-md font-semibold truncate max-w-xs">
-          wikied.kr/{info.code}
+          wikied.kr/{info.name}
         </span>
-        <LinkSVG className="text-gray-400 font-semibold w-[40px]" />
+        <LinkSVG className="text-gray-400 w-[30px]" />
       </section>
     </div>
   );

--- a/src/components/WikiCardList.tsx
+++ b/src/components/WikiCardList.tsx
@@ -18,9 +18,9 @@ interface WikiCardListProps {
 
 const WikiCardList = ({ list }: WikiCardListProps) => {
   return (
-    <div className="grid grid-cols-3 auto-rows-auto gap-[24px]">
+    <div className="grid grid-cols-3 auto-rows-auto gap-[24px] Tablet:grid-cols-2 Mobile:grid-cols-1">
       {list.map((el) => (
-        <Link key={el.id} href={`/${el.code}`}>
+        <Link key={el.id} href={`/${el.name}`}>
           <WikiCard info={el} />
         </Link>
       ))}

--- a/src/pages/wikilist/index.tsx
+++ b/src/pages/wikilist/index.tsx
@@ -24,7 +24,7 @@ interface WikiListProps {
 export const getServerSideProps: GetServerSideProps<
   WikiListProps
 > = async () => {
-  const res = await getProfiles();
+  const res = await getProfiles({ pageSize: 12 });
   return {
     props: {
       initialList: res,
@@ -70,7 +70,7 @@ const WikiList = ({ initialList }: WikiListProps) => {
   }, [loadMoreProfiles, hasMore]);
 
   return (
-    <div className="max-w-[840px] w-full mx-auto my-[40px] h-full px-[20px]">
+    <div className="max-w-[840px] w-full mx-auto h-full px-[20px] Tablet:px-[60px] Mobile:px-[100px]">
       <WikiListTitle />
       <WikiCardList list={list} />
       {hasMore && (


### PR DESCRIPTION
- 모든 위키 페이지에서 위키 눌렀을때 code 가 아닌 name으로 가게 했습니다.
- 하단에 링크 부분도 code에서 name으로 바꿨습니다
- 반응형 디자인 추가했습니다