### PR TITLE
Chore: 주소가 유저 이름으로 변경됨에 따라 디코딩 과정 추가

### DIFF
--- a/src/containers/CustomLinkContainer.tsx
+++ b/src/containers/CustomLinkContainer.tsx
@@ -10,7 +10,7 @@ const CustomLinkContainer = () => {
   const [isToastVisible, setIsToastVisible] = useState(false);
 
   useEffect(() => {
-    const url = `${window.location.origin}${router.asPath}`;
+    const url = `${window.location.origin}${decodeURIComponent(router.asPath)}`;
     setFullUrl(url);
   }, [router.asPath]);
 


### PR DESCRIPTION
위키 페이지의 URL이 `/wiki/[code]`에서 `/wiki/[name]`으로 변경됨에 따라, URL에서 유저 이름을 가져오면 한글이 인코딩된 값으로 전달됩니다. 

이를 해결하기 위해, 인코딩된 유저 이름을 디코딩하여 원래 이름을 사용할 수 있도록 수정했습니다.