### PR TITLE
Fix: paginationbar 버튼 수정

### DIFF
--- a/src/components/PaginationBar.tsx
+++ b/src/components/PaginationBar.tsx
@@ -13,6 +13,8 @@ const PaginationBar = ({
   handlePageChange,
   isLoading,
 }: PaginationBarProps) => {
+
+  if (totalPage <=1) return null
   let startPage;
   let calNum;
 


### PR DESCRIPTION
### totalPage <= 1일 때 paginationbar 보이지 않게 수정

- 페이지가 1보다 작을 때는 버튼이 없는게 사용자 경험에 좋다고 하여 반영