### PR TITLE
Refactor: useInfiniteScroll 커스텀함수로 추상화

### DIFF
--- a/src/hooks/useInfiniteScroll.tsx
+++ b/src/hooks/useInfiniteScroll.tsx
@@ -1,0 +1,45 @@
+import { getProfiles } from "@/api/profile";
+import { useCallback, useEffect, useRef, useState } from "react";
+import { Profile } from "@/types/types";
+
+const useInfiniteScroll = (initialPage: number, initialList: Profile[]) => {
+  const [list, setList] = useState<Profile[]>(initialList);
+  const [page, setPage] = useState(initialPage);
+  const [hasMore, setHasMore] = useState(true);
+  const loadingRef = useRef<HTMLDivElement | null>(null);
+
+  const loadMoreProfiles = useCallback(async () => {
+    const newProfiles = await getProfiles({ page: page + 1 });
+
+    if (newProfiles.length === 0) {
+      setHasMore(false);
+    } else {
+      setList((prev) => [...prev, ...newProfiles]);
+      setPage((prev) => prev + 1);
+    }
+  }, [page]);
+
+  useEffect(() => {
+    const currentRef = loadingRef.current;
+
+    const observer = new IntersectionObserver((entries) => {
+      if (entries[0].isIntersecting && hasMore) {
+        loadMoreProfiles();
+      }
+    });
+
+    if (currentRef) {
+      observer.observe(currentRef);
+    }
+
+    return () => {
+      if (currentRef) {
+        observer.unobserve(currentRef);
+      }
+    };
+  }, [loadMoreProfiles, hasMore]);
+
+  return { loadingRef, hasMore, list };
+};
+
+export default useInfiniteScroll;

--- a/src/pages/wikilist/index.tsx
+++ b/src/pages/wikilist/index.tsx
@@ -1,11 +1,10 @@
-// pages/WikiList.tsx
-import { useEffect, useCallback, useState, useRef } from "react";
-import { getProfiles } from "@/api/profile";
 import { GetServerSideProps } from "next";
+import { getProfiles } from "@/api/profile";
+import { Profile } from "@/types/types";
 import WikiListTitle from "@/components/WikiListTitle";
 import WikiCardList from "@/components/WikiCardList";
 import LoadingSpinner from "@/components/LoadingSpinner";
-import { Profile } from "@/types/types";
+import useInfiniteScroll from "@/hooks/useInfiniteScroll";
 
 interface WikiListProps {
   initialList: Profile[];
@@ -23,41 +22,7 @@ export const getServerSideProps: GetServerSideProps<
 };
 
 const WikiList = ({ initialList }: WikiListProps) => {
-  const [list, setList] = useState<Profile[]>(initialList);
-  const [page, setPage] = useState(1);
-  const [hasMore, setHasMore] = useState(true);
-  const loadingRef = useRef<HTMLDivElement | null>(null);
-
-  const loadMoreProfiles = useCallback(async () => {
-    const newProfiles = await getProfiles({ page: page + 1 });
-
-    if (newProfiles.length === 0) {
-      setHasMore(false);
-    } else {
-      setList((prev) => [...prev, ...newProfiles]);
-      setPage((prev) => prev + 1);
-    }
-  }, [page]);
-
-  useEffect(() => {
-    const currentRef = loadingRef.current;
-
-    const observer = new IntersectionObserver((entries) => {
-      if (entries[0].isIntersecting && hasMore) {
-        loadMoreProfiles();
-      }
-    });
-
-    if (currentRef) {
-      observer.observe(currentRef);
-    }
-
-    return () => {
-      if (currentRef) {
-        observer.unobserve(currentRef);
-      }
-    };
-  }, [loadMoreProfiles, hasMore]);
+  const { loadingRef, hasMore, list } = useInfiniteScroll(1, initialList);
 
   return (
     <div className="max-w-[840px] w-full mx-auto h-full px-[20px] Tablet:px-[60px] Mobile:px-[100px]">

--- a/src/pages/wikilist/index.tsx
+++ b/src/pages/wikilist/index.tsx
@@ -5,17 +5,7 @@ import { GetServerSideProps } from "next";
 import WikiListTitle from "@/components/WikiListTitle";
 import WikiCardList from "@/components/WikiCardList";
 import LoadingSpinner from "@/components/LoadingSpinner";
-
-interface Profile {
-  updatedAt: string;
-  job: string;
-  nationality: string;
-  city: string;
-  image: string;
-  code: string;
-  name: string;
-  id: number;
-}
+import { Profile } from "@/types/types";
 
 interface WikiListProps {
   initialList: Profile[];
@@ -24,7 +14,7 @@ interface WikiListProps {
 export const getServerSideProps: GetServerSideProps<
   WikiListProps
 > = async () => {
-  const res = await getProfiles({ pageSize: 12 });
+  const res = await getProfiles();
   return {
     props: {
       initialList: res,


### PR DESCRIPTION
기존에 12으로 설정되어있어서 page+1 될 때마다 2개씩 데이터가 겹치는 버그 개선했습니다