### PR TITLE
Fix: link props로 개별 주소 렌더링이 가능하도록 수정

### DIFF
--- a/src/containers/CustomLinkContainer.tsx
+++ b/src/containers/CustomLinkContainer.tsx
@@ -1,16 +1,17 @@
-import { useRouter } from "next/router";
 import { useEffect, useState } from "react";
 import CustomLink from "@/components/ui/CustomLink";
 import useNotify from "@/hooks/useNotify";
 
-const CustomLinkContainer = () => {
-  const router = useRouter();
+interface CustomLinkContainerProps {
+  link: string;
+}
+const CustomLinkContainer = ({ link }: CustomLinkContainerProps) => {
   const [fullUrl, setFullUrl] = useState("");
 
   useEffect(() => {
-    const url = `${window.location.origin}${decodeURIComponent(router.asPath)}`;
+    const url = `${window.location.origin}${link}`;
     setFullUrl(url);
-  }, [router.asPath]);
+  }, [link]);
 
   const notify = useNotify();
   const copyToClipboard = async () => {


### PR DESCRIPTION
### 문제
- 기존 CustomLinkContainer는 현재 페이지의 주소를 기반으로 링크가 생성되어, 한 페이지에서 여러 요소에 각각 다른 주소를 설정하는 데 어려움이 있었습니다.

### 수정 사항

- link props를 통해 개별적으로 원하는 주소를 전달할 수 있도록 변경했습니다. 
이를 통해 한 페이지에서 다양한 요소에 각각 다른 주소가 렌더링되고 복사 기능도 잘 작동하도록 개선했습니다.

### 예시
```js
<CustomLinkContainer link={`/wiki/${info.name}`} />
```