### PR TITLE
Fix: SearchInput 컴포넌트 source prop 추가

### DIFF
--- a/src/components/SearchInput.tsx
+++ b/src/components/SearchInput.tsx
@@ -3,6 +3,7 @@ import Image from "next/image";
 
 interface SearchInputProps {
   size: "large" | "medium" | "small";
+  source?: "header" | "boards";
   onSubmit: FormEventHandler;
   onChange?: ChangeEventHandler;
   value?: string;
@@ -10,6 +11,7 @@ interface SearchInputProps {
 
 export const SearchInput = ({
   size,
+  source,
   onSubmit,
   onChange,
   value,
@@ -28,7 +30,9 @@ export const SearchInput = ({
         <input
           className={`${style} p-[8px] pl-[56px] pr-[128px] border-none rounded-lg shadow-md bg-gray-100 text-gray-500 text-md focus:outline-green-100 placeholder:text-gray-400`}
           type="text"
-          placeholder="이름으로 위키 찾기"
+          placeholder={
+            source === "header" ? "이름으로 위키 찾기" : "제목으로 검색하기"
+          }
           onChange={onChange}
           value={value}
         />


### PR DESCRIPTION
## 설명
/boards 페이지에서 쓰는 SerachInput에 PlaceHolder를 다르게 하기 위해서 추가했습니다. source prop에 문자열로 "boards"라고만 넣어주시면 알아서 바뀔 겁니다.

```js
import { ChangeEventHandler, FormEventHandler } from "react";
import Image from "next/image";

interface SearchInputProps {
  size: "large" | "medium" | "small";
  source?: "header" | "boards";
  onSubmit: FormEventHandler;
  onChange?: ChangeEventHandler;
  value?: string;
}

export const SearchInput = ({
  size,
  source,
  onSubmit,
  onChange,
  value,
}: SearchInputProps) => {
  const sizes = {
    large: "w-[860px] h-[45px]",
    medium: "w-[704px] h-[45px]",
    small: "w-[335px] h-[45px]",
  };

  const style = sizes[size] || sizes.large;

  return (
    <form onSubmit={onSubmit}>
      <div className="relative">
        <input
          className={`${style} p-[8px] pl-[56px] pr-[128px] border-none rounded-lg shadow-md bg-gray-100 text-gray-500 text-md focus:outline-green-100 placeholder:text-gray-400`}
          type="text"
          placeholder={
            source === "header" ? "이름으로 위키 찾기" : "제목으로 검색하기"
          }
          onChange={onChange}
          value={value}
        />
        <button
          className={`absolute top-[10px] left-[16px] border-transparent bg-gray-100 cursor-pointer focus:outline-green-100`}
          type="submit"
        >
          <Image
            src={"/icons/ic_search.svg"}
            width={24}
            height={24}
            alt="검색 아이콘"
          />
        </button>
      </div>
    </form>
  );
};
```